### PR TITLE
Open up a way to expose the collection “PublishJoin” to the browser

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+
+language: node_js
+
+sudo: false
+
+node_js:
+  - "node"
+
+script:
+  - npm run lint

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ JoinClient.get('withPromise')
 
 ## API
 
-### JoinServer.publish(v: Object)
+### JoinServer.publish(v: Object) [Server]
 
 Use within publication to publish a value to subscriber. Require one argument having following required fields:
 
@@ -129,7 +129,7 @@ Meteor.publish('example', function(postId) {
 - This package uses a worker runs every 500 milliseconds to check for published values which have passed their `interval` time and required to re-publish. Therefore the actual `interval` value runs from `interval` to `interval + 500`
 - The worker of this package is actually a `setTimeout` loop got run every 500 milliseconds. This loop is started by the first call to `JoinServer.publish` and is cleared when the last publication containing a `JoinServer.publish` is stopped
 
-### JoinClient.get(v: String)
+### JoinClient.get(v: String) [Client]
 
 Use in client to obtain the published values. This function is reactive, it could be used in Blaze helpers, Tracker.auto, and other computation block.
 
@@ -150,6 +150,43 @@ Tracker.autorun(() => {
   console.log(JoinClient.get('numComments'));
 });
 ```
+
+### JoinClient.has(v: String) [Client]
+
+See if a value has been published. This function is reactive, it could be used in Blaze helpers, Tracker.auto, and other computation block.
+
+##### Example
+
+```javascript
+import { JoinClient } from 'meteor-publish-join';
+
+// Use in Blaze helpers
+Template.hello.helpers({
+  numComments() {
+    return JoinClient.has('numComments');
+  },
+});
+
+// Use in Tracker.autorun
+Tracker.autorun(() => {
+  console.log(JoinClient.has('numComments'));
+});
+```
+
+## Template helpers
+
+To easily show join values within your templates, use the getPublishedJoin or hasPublishedJoin template helper.
+
+Example:
+
+<p>There are {{getPublishedJoin 'numComments'}} comments.</p>
+<p>
+  {{#if hasPublishedJoin 'numComments'}}
+    There are {{getPublishedJoin 'numComments'}} comments.
+  {{else}}
+    The number of comments is loading...
+  {{/if}}
+</p>
 
 ## Todos
 

--- a/README.md
+++ b/README.md
@@ -173,21 +173,6 @@ Tracker.autorun(() => {
 });
 ```
 
-## Template helpers
-
-To easily show join values within your templates, use the getPublishedJoin or hasPublishedJoin template helper.
-
-Example:
-
-<p>There are {{getPublishedJoin 'numComments'}} comments.</p>
-<p>
-  {{#if hasPublishedJoin 'numComments'}}
-    There are {{getPublishedJoin 'numComments'}} comments.
-  {{else}}
-    The number of comments is loading...
-  {{/if}}
-</p>
-
 ## Todos
 
 - [x] Prevent re-run a publish if the last run has not finished

--- a/src/__tests__/client/index.test.js
+++ b/src/__tests__/client/index.test.js
@@ -28,7 +28,7 @@ describe('client get', () => {
   });
 
   it('should return undefined if value does not exist', () => {
-    const JoinClient = require('../../client/index').default;
+    const JoinClient = require('../../client/index').Client;
 
     const result = JoinClient.get('test');
 
@@ -36,7 +36,7 @@ describe('client get', () => {
   });
 
   it('should return exact value of id', () => {
-    const JoinClient = require('../../client/index').default;
+    const JoinClient = require('../../client/index').Client;
 
     map.test = {
       value: 'test',

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -1,29 +1,24 @@
-/* global Meteor, Mongo */
+/* global Meteor, Mongo, Package */
 
 const client = new Mongo.Collection('PublishJoin');
 
 client.get = function get(name) {
-	const join = this.findOne({
-	  _id: name,
-	});
+  const join = this.findOne({
+    _id: name,
+  });
 
-	return join && join.value;
+  return join && join.value;
 };
 
 client.has = function get(name) {
-	return !!this.findOne({
-	  _id: name,
-	});
+  return !!this.findOne({
+    _id: name,
+  });
 };
 
 if (Package.templating) {
-  Package.templating.Template.registerHelper('getPublishedJoin', function(name) {
-    return client.get(name);
-  });
-
-  Package.templating.Template.registerHelper('hasPublishedJoin', function(name) {
-    return client.has(name);
-  });
+  Package.templating.Template.registerHelper('getPublishedJoin', name => client.get(name));
+  Package.templating.Template.registerHelper('hasPublishedJoin', name => client.has(name));
 }
 
 export default client;

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -1,24 +1,30 @@
 /* global Meteor, Mongo, Package */
 
-const client = new Mongo.Collection('PublishJoin');
+let collection = {};
 
-client.get = function get(name) {
-  const join = this.findOne({
-    _id: name,
-  });
+if (typeof Meteor !== 'undefined' && Meteor.isClient) {
+  collection = new Mongo.Collection('PublishJoin');
 
-  return join && join.value;
-};
+  collection.get = function get(name) {
+    const join = this.findOne({
+      _id: name,
+    });
 
-client.has = function get(name) {
-  return !!this.findOne({
-    _id: name,
-  });
-};
+    return join && join.value;
+  };
 
-if (Package.templating) {
-  Package.templating.Template.registerHelper('getPublishedJoin', name => client.get(name));
-  Package.templating.Template.registerHelper('hasPublishedJoin', name => client.has(name));
+  collection.has = function get(name) {
+    return !!this.findOne({
+      _id: name,
+    });
+  };
+
+  if (Package.templating) {
+    Package.templating.Template.registerHelper('getPublishedJoin', name => collection.get(name));
+    Package.templating.Template.registerHelper('hasPublishedJoin', name => collection.has(name));
+  }
 }
+
+const client = collection;
 
 export default client;

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -1,17 +1,29 @@
 /* global Meteor, Mongo */
 
-const client = {};
+const client = new Mongo.Collection('PublishJoin');
 
-if (typeof Meteor !== 'undefined' && Meteor.isClient) {
-  const JoinCollection = new Mongo.Collection('PublishJoin');
+client.get = function get(name) {
+	const join = this.findOne({
+	  _id: name,
+	});
 
-  client.get = function get(name) {
-    const join = JoinCollection.findOne({
-      _id: name,
-    });
+	return join && join.value;
+};
 
-    return join && join.value;
-  };
+client.has = function get(name) {
+	return !!this.findOne({
+	  _id: name,
+	});
+};
+
+if (Package.templating) {
+  Package.templating.Template.registerHelper('getPublishedJoin', function(name) {
+    return client.get(name);
+  });
+
+  Package.templating.Template.registerHelper('hasPublishedJoin', function(name) {
+    return client.has(name);
+  });
 }
 
 export default client;

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -1,30 +1,30 @@
 /* global Meteor, Mongo, Package */
 
-let collection = {};
+const client = {};
+let collection;
 
 if (typeof Meteor !== 'undefined' && Meteor.isClient) {
   collection = new Mongo.Collection('PublishJoin');
 
-  collection.get = function get(name) {
-    const join = this.findOne({
+  client.get = function get(name) {
+    const join = collection.findOne({
       _id: name,
     });
 
     return join && join.value;
   };
 
-  collection.has = function get(name) {
-    return !!this.findOne({
+  client.has = function get(name) {
+    return !!collection.findOne({
       _id: name,
     });
   };
 
   if (Package.templating) {
-    Package.templating.Template.registerHelper('getPublishedJoin', name => collection.get(name));
-    Package.templating.Template.registerHelper('hasPublishedJoin', name => collection.has(name));
+    Package.templating.Template.registerHelper('getPublishedJoin', name => client.get(name));
+    Package.templating.Template.registerHelper('hasPublishedJoin', name => client.has(name));
   }
 }
 
-const client = collection;
-
-export default client;
+export const Client = client;
+export const Collection = collection;

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -1,4 +1,4 @@
-/* global Meteor, Mongo, Package */
+/* global Meteor, Mongo */
 
 const client = {};
 let collection;
@@ -14,16 +14,11 @@ if (typeof Meteor !== 'undefined' && Meteor.isClient) {
     return join && join.value;
   };
 
-  client.has = function get(name) {
+  client.has = function has(name) {
     return !!collection.findOne({
       _id: name,
     });
   };
-
-  if (Package.templating) {
-    Package.templating.Template.registerHelper('getPublishedJoin', name => client.get(name));
-    Package.templating.Template.registerHelper('hasPublishedJoin', name => client.has(name));
-  }
 }
 
 export const Client = client;

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -15,9 +15,9 @@ if (typeof Meteor !== 'undefined' && Meteor.isClient) {
   };
 
   client.has = function has(name) {
-    return !!collection.findOne({
+    return collection.find({
       _id: name,
-    });
+    }, { limit: 1 }).count() > 0;
   };
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 // Package goes here
 import JoinServer from './server';
-import JoinClient from './client';
+import { Client as JoinClient, Collection as JoinClientCollection } from './client';
 
 if (typeof Meteor === 'undefined') {
   throw new Error('PublishJoin can only be used in a Meteor project');
@@ -9,4 +9,5 @@ if (typeof Meteor === 'undefined') {
 export {
   JoinServer,
   JoinClient,
+  JoinClientCollection,
 };


### PR DESCRIPTION
I like the way the publish-count plugin allows you to expose the collection for counts to the browser. It makes debugging quite easy (see: https://github.com/percolatestudio/publish-counts/blob/master/client/publish-counts.js)

I've also adjusted the client here to open for exposing the internally used collection to the browser.

In addition, I've also taken over the `has` method, publish-counts has at it's client-side collection and added helpers for Blaze, that just are imported if Blaze is loaded. Haven't tested them, but I thought it would be worth adding them as well 😉 