### PR TITLE
Added compatibility to johanbrook:publication-collector

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+
+language: node_js
+
+sudo: false
+
+node_js:
+  - "node"
+
+script:
+  - npm run lint

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -12,7 +12,9 @@ import {
   throwError,
 } from '../helpers';
 
-const server = {};
+const server = {
+  testMode: false,
+};
 
 function validate(data) {
   const {
@@ -66,13 +68,17 @@ if (typeof Meteor !== 'undefined' && Meteor.isServer) {
 
     const join = new Join(data);
 
-    store.addJoin(join);
+    if (this.testMode) {
+      join.publish();
+    } else {
+      store.addJoin(join);
 
-    if (needStartWorker) {
-      startPublishWorker(store);
+      if (needStartWorker) {
+        startPublishWorker(store);
+      }
+
+      setUpOnStopHandlerForJoin(join, store);
     }
-
-    setUpOnStopHandlerForJoin(join, store);
   };
 }
 


### PR DESCRIPTION
Added option (tesetMode) to run joins synchronous (blocking) and without interval in order to test their result.

By enabling this method, I archived two of the following goals:

* Run the `Join.publish()` call synchronous
* Start calling `Join.publish()` immediately
* Stop the subscription after we are not subscribing it anymore (could be an issue of `johanbrook:publication-collector` ... )

Please let me know if you have a better idea, but I need the publication to run at once, sync and (preferably) only once if I want to use it with `johanbrook:publication-collector`. Adding a variable to the server-instance just seemed as a great opportunity to me.

If you think this is a good way to go, it should also be noted in the `Readme.md` file 😉 