### PR TITLE
Fix removing of multiple subscriptions from a join at once

### DIFF
--- a/src/__tests__/server/Join.test.js
+++ b/src/__tests__/server/Join.test.js
@@ -242,7 +242,7 @@ describe('Join class', () => {
   });
 
   describe('removeContext', () => {
-    it('should remove context if _subscriptionId matches', () => {
+    it('should remove context if _subscriptionId and connection._id matches', () => {
       const join = new Join({
         name: 'joinName',
         interval: 1000,
@@ -254,9 +254,65 @@ describe('Join class', () => {
         },
         isShared: false,
       });
-      const context1 = { _subscriptionId: 'sub1' };
-      const context2 = { _subscriptionId: 'sub2' };
-      const context3 = { _subscriptionId: 'sub3' };
+      const context1 = { _subscriptionId: 'sub1', connection: { _id: 'id1' } };
+      const context2 = { _subscriptionId: 'sub2', connection: { _id: 'id1' } };
+      const context3 = { _subscriptionId: 'sub3', connection: { _id: 'id2' } };
+      const testContexts = [context1, context2, context3];
+
+      join.contexts = [...testContexts];
+
+      join.removeContext(context1);
+
+      expect(join.contexts).to.have.lengthOf(2);
+      expect(join.contexts).to.have.deep.property('[0]')
+        .that.deep.equals(context2);
+      expect(join.contexts).to.have.deep.property('[1]')
+        .that.deep.equals(context3);
+    });
+
+    it('should only remove one context if _subscriptionId and connection._id matches only one', () => {
+      const join = new Join({
+        name: 'joinName',
+        interval: 1000,
+        maxWaiting: 1000,
+        doJoin() {},
+        context: {
+          added() {},
+          changed() {},
+        },
+        isShared: false,
+      });
+      const context1 = { _subscriptionId: 'sub1', connection: { _id: 'id2' } };
+      const context2 = { _subscriptionId: 'sub1', connection: { _id: 'id1' } };
+      const context3 = { _subscriptionId: 'sub3', connection: { _id: 'id2' } };
+      const testContexts = [context1, context2, context3];
+
+      join.contexts = [...testContexts];
+
+      join.removeContext(context1);
+
+      expect(join.contexts).to.have.lengthOf(2);
+      expect(join.contexts).to.have.deep.property('[0]')
+        .that.deep.equals(context2);
+      expect(join.contexts).to.have.deep.property('[1]')
+        .that.deep.equals(context3);
+    });
+
+    it('should only remove one context if _subscriptionId and connection._id matches many', () => {
+      const join = new Join({
+        name: 'joinName',
+        interval: 1000,
+        maxWaiting: 1000,
+        doJoin() {},
+        context: {
+          added() {},
+          changed() {},
+        },
+        isShared: false,
+      });
+      const context1 = { _subscriptionId: 'sub1', connection: { _id: 'id1' } };
+      const context2 = { _subscriptionId: 'sub1', connection: { _id: 'id1' } };
+      const context3 = { _subscriptionId: 'sub3', connection: { _id: 'id2' } };
       const testContexts = [context1, context2, context3];
 
       join.contexts = [...testContexts];

--- a/src/server/Join.js
+++ b/src/server/Join.js
@@ -66,10 +66,20 @@ export default class Join {
       (now - this._getLastPublishedTime() >= this.interval);
   }
 
-  removeContext({ _subscriptionId }) {
-    this.contexts = this.contexts.filter(
-      context => context._subscriptionId !== _subscriptionId,
-    );
+  _findContextIndex({ _subscriptionId }) {
+    return this.contexts.findIndex(c => c._subscriptionId === _subscriptionId);
+  }
+
+  _removeContextAtIndex(index) {
+    if (index > -1) {
+      this.contexts.splice(index, 1);
+    }
+  }
+
+  removeContext(context) {
+    const contextIndex = this._findContextIndex(context);
+
+    this._removeContextAtIndex(contextIndex);
   }
 
   addContext(context) {

--- a/src/server/Join.js
+++ b/src/server/Join.js
@@ -66,8 +66,10 @@ export default class Join {
       (now - this._getLastPublishedTime() >= this.interval);
   }
 
-  _findContextIndex({ _subscriptionId }) {
-    return this.contexts.findIndex(c => c._subscriptionId === _subscriptionId);
+  _findContextIndex({ _subscriptionId, connection }) {
+    return this.contexts.findIndex(c =>
+      c._subscriptionId === _subscriptionId &&
+      c.connection.id === connection.id);
   }
 
   _removeContextAtIndex(index) {


### PR DESCRIPTION
The previous code had the chance of removing multiple subscriptions from a single join multiple times, because they had the same subscription-id.

If this is not intended, we should rather switch to a `Set` for storing these elements and then have a different stopping mechanism, but this is at least better than what we had before.

This is a first attempt to fix #16 