### PR TITLE
Fixed exceptions in tests where no connection exists

### DIFF
--- a/src/server/Join.js
+++ b/src/server/Join.js
@@ -72,7 +72,7 @@ export default class Join {
   _findContextIndex({ _subscriptionId, connection }) {
     return this.contexts.findIndex(c =>
       c._subscriptionId === _subscriptionId &&
-      c.connection.id === connection.id);
+      (c.connection || {}).id === (connection || {}).id);
   }
 
   _removeContextAtIndex(index) {


### PR DESCRIPTION
The latest changes introduced a check on the connections id, which is not available in unit-tests when running the subscription using `johanbrook:publication-collector`